### PR TITLE
VP-1310: Fix NullReference in DeepLoadSettings

### DIFF
--- a/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
+++ b/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
@@ -11,9 +11,10 @@ namespace VirtoCommerce.PaymentModule.Core.Model
 {
     public abstract class PaymentMethod : Entity, IHasSettings, IHasTaxDetalization, ITaxable, ICloneable
     {
-        public PaymentMethod(string code)
+        protected PaymentMethod(string code)
         {
             Code = code;
+            Settings = Array.Empty<ObjectSettingEntry>();
         }
 
         /// <summary>


### PR DESCRIPTION
- Initializing Settings with empty collection prevents NullReference if payment method has properties that use Settings;