### PR TITLE
PT-6847: Obsolete Name field is removed from the payment method class

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.202.0-beta2</VersionPrefix>
+    <VersionPrefix>3.202.0-beta3</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.202.0-beta3</VersionPrefix>
+    <VersionPrefix>3.202.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.202.0</VersionPrefix>
+    <VersionPrefix>3.202.0-beta2</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
+++ b/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
@@ -13,9 +13,11 @@ namespace VirtoCommerce.PaymentModule.Core.Model
     {
         protected PaymentMethod(string code)
         {
-            Code = code;
+            Code = Name = code;
             Settings = Array.Empty<ObjectSettingEntry>();
         }
+
+        public string Name { get; set; }
 
         /// <summary>
         /// Method identity property (system name)

--- a/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
+++ b/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
@@ -17,13 +17,11 @@ namespace VirtoCommerce.PaymentModule.Core.Model
             Settings = Array.Empty<ObjectSettingEntry>();
         }
 
-        public string Name { get; set; }
-
         /// <summary>
         /// Method identity property (system name)
         /// </summary>
         public string Code { get; set; }
-
+        public string Name { get; set; }
         public string LogoUrl { get; set; }
         public bool IsActive { get; set; }
         public int Priority { get; set; }

--- a/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
+++ b/src/VirtoCommerce.Payment.Core/Model/PaymentMethod.cs
@@ -22,12 +22,6 @@ namespace VirtoCommerce.PaymentModule.Core.Model
         /// </summary>
         public string Code { get; set; }
 
-        /// <summary>
-        /// It's the same as <see>Code</see>. Left for backward compatibility. Should be removed in future.
-        /// </summary>
-        [Obsolete("Left for backward compatibility. Should be removed in future. Use Code.")]
-        public string Name => Code;
-
         public string LogoUrl { get; set; }
         public bool IsActive { get; set; }
         public int Priority { get; set; }

--- a/src/VirtoCommerce.Payment.Web/Module.cs
+++ b/src/VirtoCommerce.Payment.Web/Module.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.PaymentModule.Core;
 using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model.Search;
 using VirtoCommerce.PaymentModule.Core.Services;
 using VirtoCommerce.PaymentModule.Data;
 using VirtoCommerce.PaymentModule.Data.ExportImport;
@@ -14,6 +15,7 @@ using VirtoCommerce.PaymentModule.Data.Repositories;
 using VirtoCommerce.PaymentModule.Data.Services;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.Platform.Core.JsonConverters;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
@@ -34,10 +36,11 @@ namespace VirtoCommerce.PaymentModule.Web
             serviceCollection.AddDbContext<PaymentDbContext>(options => options.UseSqlServer(connectionString));
             serviceCollection.AddTransient<IPaymentRepository, PaymentRepository>();
             serviceCollection.AddTransient<Func<IPaymentRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetService<IPaymentRepository>());
-
-            serviceCollection.AddTransient<IPaymentMethodsService, PaymentMethodsService>();
+            serviceCollection.AddTransient<ISearchService<PaymentMethodsSearchCriteria, PaymentMethodsSearchResult, PaymentMethod>, PaymentMethodsSearchService>();
+            serviceCollection.AddTransient(x => (IPaymentMethodsSearchService)x.GetRequiredService<ISearchService<PaymentMethodsSearchCriteria, PaymentMethodsSearchResult, PaymentMethod>>());
+            serviceCollection.AddTransient<ICrudService<PaymentMethod>, PaymentMethodsService>();
+            serviceCollection.AddTransient(x => (IPaymentMethodsService)x.GetRequiredService<ICrudService<PaymentMethod>>());
             serviceCollection.AddTransient<IPaymentMethodsRegistrar, PaymentMethodsService>();
-            serviceCollection.AddTransient<IPaymentMethodsSearchService, PaymentMethodsSearchService>();
             serviceCollection.AddTransient<PaymentExportImport>();
         }
 

--- a/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-detail.js
+++ b/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-detail.js
@@ -2,7 +2,7 @@ angular.module('virtoCommerce.paymentModule').controller('virtoCommerce.paymentM
     var blade = $scope.blade;
 
     function initializeBlade(data) {
-        blade.title = 'payment.labels.' + data.typeName + '.name';
+        blade.title = data.name ? data.name : 'payment.labels.' + data.typeName + '.name';
         blade.currentEntity = angular.copy(data);
         blade.origEntity = data;
         blade.isLoading = false;

--- a/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-detail.tpl.html
+++ b/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-detail.tpl.html
@@ -7,7 +7,8 @@
                         <ul class="list __info">
                             <li class="list-item">
                                 <div class="list-t">{{ 'payment.blades.payment-method-detail.labels.name' | translate }}</div>
-                                <div class="list-descr">{{ 'payment.labels.' + blade.currentEntity.typeName + '.name' | translate }}</div>
+                                <div class="list-descr" ng-if="blade.currentEntity.name">{{ blade.currentEntity.name }}</div>
+                                <div class="list-descr" ng-if="!blade.currentEntity.name">{{ 'payment.labels.' + blade.currentEntity.typeName + '.name' | translate }}</div>
                             </li>
                         </ul>
                     </div>

--- a/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-list.js
+++ b/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-list.js
@@ -1,4 +1,4 @@
-angular.module('virtoCommerce.paymentModule').controller('virtoCommerce.paymentModule.paymentMethodListController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.paymentModule.paymentMethods', function ($scope, bladeNavigationService, paymentMethods) {
+angular.module('virtoCommerce.paymentModule').controller('virtoCommerce.paymentModule.paymentMethodListController', ['$scope', '$translate', 'platformWebApp.bladeNavigationService', 'virtoCommerce.paymentModule.paymentMethods', function ($scope, $translate, bladeNavigationService, paymentMethods) {
     var blade = $scope.blade;
 
     function initializeBlade() {
@@ -32,6 +32,18 @@ angular.module('virtoCommerce.paymentModule').controller('virtoCommerce.paymentM
             storeId: blade.storeId
         }, function (data) {
             blade.isLoading = false;
+
+            _.each(data.results, function (item) {
+                var nameTranslationKey = "payment.labels." + item.typeName + ".name";
+                var descriptionTranslateKey = "payment.labels." + item.typeName + ".description";
+
+                var nameResult = $translate.instant(nameTranslationKey);
+                var displayDescription = $translate.instant(descriptionTranslateKey);
+
+                item.displayName = nameResult === nameTranslationKey ? item.name : nameResult;
+                item.displayDescription = displayDescription === descriptionTranslateKey ? item.description : displayDescription;
+            });
+
             blade.currentEntities = data.results;
             blade.selectedPaymentMethods = _.findWhere(blade.currentEntities, { isActive: true });
         }, function (error) {

--- a/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-list.tpl.html
+++ b/src/VirtoCommerce.Payment.Web/Scripts/blades/paymentMethod-list.tpl.html
@@ -28,10 +28,12 @@
                             </td>
                             <td class="table-col __product-name" ng-click='selectNode(data)'>
                                 <span>
-                                    <div class="table-t">{{"payment.labels." + data.typeName + ".name" | translate }}
+                                    <div class="table-t">
+                                        {{ data.displayName }}
                                     </div>
                                     <div class="table-descr">
-                                        {{"payment.labels." + data.typeName + ".description" | translate }}</div>
+                                        {{ data.displayDescription }}
+                                    </div>
                                 </span>
                             </td>
                         </tr>

--- a/src/VirtoCommerce.Payment.Web/module.manifest
+++ b/src/VirtoCommerce.Payment.Web/module.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <id>VirtoCommerce.Payment</id>
-    <version>3.202.0-beta2</version>
+    <version>3.202.0-beta3</version>
     <version-tag />
     <platformVersion>3.200.0</platformVersion>
     <title>Payment module</title>

--- a/src/VirtoCommerce.Payment.Web/module.manifest
+++ b/src/VirtoCommerce.Payment.Web/module.manifest
@@ -1,1 +1,31 @@
-﻿<?xml version="1.0" encoding="utf-8"?><module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><id>VirtoCommerce.Payment</id><version>3.202.0</version><version-tag /><platformVersion>3.200.0</platformVersion><title>Payment module</title><description>Add payment methods management</description><authors><author>Virto Commerce</author></authors><owners><owner>Virto Commerce</owner></owners><projectUrl>https://virtocommerce.com/apps/extensions/virto-payment-module</projectUrl><iconUrl>Modules/$(VirtoCommerce.Payment)/Content/logo.png</iconUrl><requireLicenseAcceptance>false</requireLicenseAcceptance><releaseNotes /><copyright>Copyright © 2011-2021 Virto Commerce. All rights reserved</copyright><tags>payments</tags><assemblyFile>VirtoCommerce.PaymentModule.Web.dll</assemblyFile><moduleType>VirtoCommerce.PaymentModule.Web.Module, VirtoCommerce.PaymentModule.Web</moduleType><dependencies><dependency id="VirtoCommerce.Core" version="3.200.0" /><dependency id="VirtoCommerce.Store" version="3.200.0" /></dependencies><groups><group>commerce</group></groups><useFullTypeNameInSwagger>false</useFullTypeNameInSwagger></module>
+<?xml version="1.0" encoding="utf-8"?>
+<module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <id>VirtoCommerce.Payment</id>
+    <version>3.202.0-beta2</version>
+    <version-tag />
+    <platformVersion>3.200.0</platformVersion>
+    <title>Payment module</title>
+    <description>Add payment methods management</description>
+    <authors>
+        <author>Virto Commerce</author>
+    </authors>
+    <owners>
+        <owner>Virto Commerce</owner>
+    </owners>
+    <projectUrl>https://virtocommerce.com/apps/extensions/virto-payment-module</projectUrl>
+    <iconUrl>Modules/$(VirtoCommerce.Payment)/Content/logo.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes />
+    <copyright>Copyright © 2011-2021 Virto Commerce. All rights reserved</copyright>
+    <tags>payments</tags>
+    <assemblyFile>VirtoCommerce.PaymentModule.Web.dll</assemblyFile>
+    <moduleType>VirtoCommerce.PaymentModule.Web.Module, VirtoCommerce.PaymentModule.Web</moduleType>
+    <dependencies>
+        <dependency id="VirtoCommerce.Core" version="3.200.0" />
+        <dependency id="VirtoCommerce.Store" version="3.200.0" />
+    </dependencies>
+    <groups>
+        <group>commerce</group>
+    </groups>
+    <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
+</module>

--- a/src/VirtoCommerce.Payment.Web/module.manifest
+++ b/src/VirtoCommerce.Payment.Web/module.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <id>VirtoCommerce.Payment</id>
-    <version>3.202.0-beta3</version>
+    <version>3.202.0</version>
     <version-tag />
     <platformVersion>3.200.0</platformVersion>
     <title>Payment module</title>


### PR DESCRIPTION
## Description
Obsolete Name field is removed from the payment method class
## References
### QA-test:
### Jira-link:




 https://virtocommerce.atlassian.net/browse/PT-6847
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Payment_3.202.0-pr-35.zip
