### PR TITLE
fix broken override for payment methods

### DIFF
--- a/src/VirtoCommerce.Payment.Data/Services/PaymentMethodsSearchService.cs
+++ b/src/VirtoCommerce.Payment.Data/Services/PaymentMethodsSearchService.cs
@@ -41,7 +41,7 @@ namespace VirtoCommerce.PaymentModule.Data.Services
             var query = ((IPaymentRepository)repository).PaymentMethods;
 
             // Return only registered payment methods
-            var registeredPaymentMethods = AbstractTypeFactory<PaymentMethod>.AllTypeInfos.Select(x => x.Type.Name).ToArray();
+            var registeredPaymentMethods = AbstractTypeFactory<PaymentMethod>.AllTypeInfos.Select(x => x.TypeName).ToArray();
             query = query.Where(x => registeredPaymentMethods.Contains(x.Code));
 
             if (!string.IsNullOrEmpty(criteria.Keyword))


### PR DESCRIPTION
## Description
Breaking changes.
When overriding the payment method while preserving the base method name, the new payment method type name is used and old  type name is not used anymore. This commit fixes the issue. 
Example of code that override the payment method with preserve the base method name:
```C#
  AbstractTypeFactory<PaymentMethod>.OverrideType<SkyflowPaymentMethod, OpusSkyflowPaymentMethod>()
                                   .WithFactory(() => appBuilder.ApplicationServices.GetService<OpusSkyflowPaymentMethod>())
                                   .WithTypeName(nameof(SkyflowPaymentMethod));
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Payment_3.807.0-pr-64-b199.zip