### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.814.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/README.md
+++ b/README.md
@@ -1,23 +1,560 @@
-# Virto Commerce Payment Module
+# Payment Module
 
 [![CI status](https://github.com/VirtoCommerce/vc-module-payment/workflows/Module%20CI/badge.svg?branch=dev)](https://github.com/VirtoCommerce/vc-module-payment/actions?query=workflow%3A"Module+CI") [![Quality gate](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-payment&metric=alert_status&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-payment) [![Reliability rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-payment&metric=reliability_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-payment) [![Security rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-payment&metric=security_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-payment) [![Sqale rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-payment&metric=sqale_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-payment)
 
-The Payment Module provides the ability to extend payment provider list with custom providers and also provides an interface and API for managing these payment providers.
+## Overview
 
-## Key features
+The Payment module provides management and integration of various payment methods within the Virto Commerce platform. It defines an extensible abstraction for payment processing — including payment registration, post-processing verification, void, capture, and refund operations — and exposes a REST API and admin UI for configuring which payment methods are active per store. The module ships with a built-in `DefaultManualPaymentMethod` and allows other modules to register custom payment method implementations at runtime through the `IPaymentMethodsRegistrar` interface.
 
-* Register payment methods using the code
-* Receive the list of payment methods on UI in VC admin
-* Edit payment method settings
-* Connect the payment methods to a Store
-* The selected payment methods will be available for selection on the Storefront
-* API to work with payment method list
+## Key Features
+
+* **Extensible payment method registration** — Register custom payment methods via code using `IPaymentMethodsRegistrar.RegisterPaymentMethod<T>()`; payment methods are resolved through `AbstractTypeFactory` polymorphism
+* **Full payment lifecycle** — Abstract `PaymentMethod` base class supports Process, PostProcess, Void, Capture, and Refund operations with both synchronous (obsolete) and async APIs
+* **Per-store configuration** — Each payment method is persisted per store with settings for activation, priority, logo, deferred payment, partial payment availability, and localized display names
+* **Search and filtering** — Search payment methods by store, code, keyword, and active status; includes both persisted and transient (registered but not yet configured) methods in results
+* **Built-in manual payment method** — `DefaultManualPaymentMethod` provides an out-of-the-box payment method supporting capture and refund flows for manual/offline payment scenarios
+* **Localized display names** — Payment methods support localized names per language through the `PaymentMethodLocalizedName` entity
+* **Domain events** — Publishes `PaymentMethodChangeEvent` (before save), `PaymentMethodChangedEvent` (after save), and `PaymentMethodInstancingEvent` (before instantiation) for extensibility
+* **Export/Import** — Full platform export/import support for payment method configurations with batched processing
+* **Multi-database support** — Entity Framework Core migrations for SQL Server, PostgreSQL, and MySQL
+* **Polymorphic JSON serialization** — Custom `PaymentMethodsJsonConverter` enables correct deserialization of payment method subtypes via the `TypeName` discriminator
+
+## Configuration
+
+### Application Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `VirtoCommerce.Payment.DefaultManualPaymentMethod.ExampleSetting` | ShortText | *(empty)* | Example setting for the built-in DefaultManualPaymentMethod; serves as a template for custom payment method settings |
+
+### Permissions
+
+This module does not define its own permissions. All API endpoints require authentication (`[Authorize]` attribute). Access control is inherited from the platform's general authorization policies.
+
+## Architecture
+
+### Key Flow
+
+1. **Registration** — During module initialization (`PostInitialize`), payment methods are registered with `IPaymentMethodsRegistrar.RegisterPaymentMethod<T>()`, which adds them to `AbstractTypeFactory<PaymentMethod>`
+2. **Configuration** — Operators configure payment methods per store via the admin UI or REST API; configurations are persisted as `StorePaymentMethodEntity` records with localized names
+3. **Search / Discovery** — `PaymentMethodsSearchService` queries persisted methods from the database, then appends transient (registered but unconfigured) methods, filtering by store, code, keyword, and active status
+4. **Instantiation** — When a payment method is loaded from the database, `PaymentMethodInstancingEvent` is published so that dependent modules (e.g., NativePaymentMethods) can register their types before `AbstractTypeFactory` resolves the concrete type
+5. **Settings hydration** — After entity-to-model conversion, `ISettingsManager.DeepLoadSettingsAsync` loads method-specific settings into the `PaymentMethod.Settings` collection
+6. **Payment processing** — The storefront or order module calls the async methods on the resolved `PaymentMethod` instance: `ProcessPaymentAsync` → `PostProcessPaymentAsync` → `CaptureProcessPaymentAsync` / `VoidProcessPaymentAsync` / `RefundProcessPaymentAsync`
+7. **Persistence** — Updates flow through `PaymentMethodsService.SaveChangesAsync`, which persists entity data and deep-saves settings, publishing change events before and after
+
+## Components
+
+### Projects
+
+| Project | Layer | Purpose |
+|---------|-------|---------|
+| `VirtoCommerce.PaymentModule.Core` | Core/Domain | Domain models (`PaymentMethod`, request/result types, enums), service interfaces (`IPaymentMethodsRegistrar`, `IPaymentMethodsService`, `IPaymentMethodsSearchService`), domain events, and module constants/settings |
+| `VirtoCommerce.PaymentModule.Data` | Data/Infrastructure | Service implementations (`PaymentMethodsService`, `PaymentMethodsSearchService`), EF Core entities and repository (`PaymentRepository`, `PaymentDbContext`), caching (`PaymentCacheRegion`), export/import, and `DefaultManualPaymentMethod` |
+| `VirtoCommerce.PaymentModule.Web` | Web/Presentation | ASP.NET Core module entry point (`Module`), REST API controller (`PaymentModuleController`), custom JSON converter, and admin UI assets |
+| `VirtoCommerce.PaymentModule.Data.SqlServer` | Database Provider | EF Core migrations and configuration for SQL Server |
+| `VirtoCommerce.PaymentModule.Data.PostgreSql` | Database Provider | EF Core migrations and configuration for PostgreSQL |
+| `VirtoCommerce.PaymentModule.Data.MySql` | Database Provider | EF Core migrations and configuration for MySQL |
+| `VirtoCommerce.Payment.Tests` | Tests | Unit and integration tests for payment method functionality |
+
+### Key Services
+
+| Service | Interface | Responsibility |
+|---------|-----------|---------------|
+| `PaymentMethodsService` | `IPaymentMethodsService`, `IPaymentMethodsRegistrar` | CRUD operations for payment methods with settings deep-load/save; registers payment method types into `AbstractTypeFactory`; publishes instancing events during entity-to-model conversion |
+| `PaymentMethodsSearchService` | `IPaymentMethodsSearchService` | Searches persisted payment methods with filtering (store, code, keyword, active status) and appends transient registered-but-unconfigured methods to results |
+| `PaymentRepository` | `IPaymentRepository` | EF Core data access for `StorePaymentMethodEntity` with eager loading of localized names |
+| `PaymentExportImport` | — | Batched export/import of payment method configurations via platform's export/import infrastructure |
+| `DefaultManualPaymentMethod` | — | Built-in manual payment method implementing `ISupportCaptureFlow` and `ISupportRefundFlow`; auto-approves Process, Capture, Void, and Refund operations |
+
+### REST API
+
+Base route: `api/payment`
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `api/payment` | Get all registered payment method types (returns prototype instances of each registered type) |
+| `POST` | `api/payment/search` | Search payment methods by criteria (store, keyword, codes, active status) with paging and sorting |
+| `GET` | `api/payment/{id}` | Get a specific payment method configuration by its ID |
+| `PUT` | `api/payment` | Create or update a payment method configuration (activation, priority, settings, localized names, etc.) |
+
+## Developer Guide: Payment Flow End-to-End
+
+This section explains how payments work across the entire Virto Commerce stack — from the Vue.js storefront, through the XAPI GraphQL layer, down to the `PaymentMethod` abstraction — and provides a step-by-step guide for developing a custom payment method.
+
+### End-to-End Payment Architecture
+
+```
+┌──────────────┐     GraphQL      ┌──────────────┐     Domain       ┌──────────────────┐
+│   Frontend   │ ──────────────►  │  XAPI Layer  │ ─────────────►   │  Payment Method  │
+│  (Vue.js)    │                  │ x-cart/x-order│                  │  (your module)   │
+└──────────────┘                  └──────────────┘                  └──────────────────┘
+      │                                 │                                    │
+      │ 1. addOrUpdateCartPayment       │                                    │
+      │ 2. createOrderFromCart          │                                    │
+      │ 3. initializePayment      ────►│ ProcessPaymentAsync()         ────►│ Gateway API
+      │ 4. [redirect / form / done]     │                                    │
+      │ 5. authorizePayment       ────►│ ValidatePostProcessRequestAsync()  │
+      │                            ────►│ PostProcessPaymentAsync()     ────►│ Gateway API
+      │                                 │                                    │
+      │         Back-office only:       │                                    │
+      │                            ────►│ CaptureProcessPaymentAsync() ────►│ Gateway API
+      │                            ────►│ VoidProcessPaymentAsync()    ────►│ Gateway API
+      │                            ────►│ RefundProcessPaymentAsync()  ────►│ Gateway API
+```
+
+### Component Responsibilities
+
+| Layer | Module | Responsibility |
+|-------|--------|---------------|
+| **Frontend** | [vc-frontend](https://github.com/VirtoCommerce/vc-frontend) | Renders payment method selection, handles redirect/form/standard flows, passes callback parameters back to backend |
+| **XAPI (Cart)** | [vc-module-x-cart](https://github.com/VirtoCommerce/vc-module-x-cart) | `addOrUpdateCartPayment` mutation — attaches payment method to cart, validates gateway code against active store methods |
+| **XAPI (Order)** | [vc-module-x-order](https://github.com/VirtoCommerce/vc-module-x-order) | `createOrderFromCart`, `initializePayment`, `authorizePayment` mutations — orchestrates order creation and calls `PaymentMethod` lifecycle methods |
+| **Payment Module** | vc-module-payment (this module) | Abstract `PaymentMethod` base class, registration infrastructure, per-store configuration persistence |
+| **Payment Provider** | e.g. [vc-module-cyber-source](https://github.com/VirtoCommerce/vc-module-cyber-source) | Concrete `PaymentMethod` implementation that communicates with the external payment gateway |
+
+### Checkout Flow Step-by-Step
+
+#### Step 1: Payment Method Selection (Frontend → x-cart)
+
+The frontend queries `availablePaymentMethods` from the cart and displays them as radio buttons. When the user selects one, the frontend calls:
+
+```graphql
+mutation AddOrUpdateCartPayment($command: InputAddOrUpdateCartPaymentType!) {
+  addOrUpdateCartPayment(command: $command) {
+    id
+    payments { id paymentGatewayCode }
+  }
+}
+```
+
+**x-cart internals:** The `AddOrUpdateCartPaymentCommandHandler` loads the cart aggregate, maps the input to a `Payment` object, validates the `paymentGatewayCode` against active store payment methods via `CartPaymentValidator`, and persists. If the code doesn't match any active method, the error `PAYMENT_METHOD_UNAVAILABLE` is returned.
+
+#### Step 2: Order Creation (Frontend → x-order)
+
+The frontend calls `createOrderFromCart`. This validates the entire cart (including the `"payments"` rule set that re-checks payment method availability), creates the order with payments transferred from the cart, then clears the cart.
+
+```graphql
+mutation CreateOrderFromCart($command: InputCreateOrderFromCartType!) {
+  createOrderFromCart(command: $command) {
+    id
+    number
+    inPayments { id gatewayCode paymentMethod { code paymentMethodType paymentMethodGroupType } }
+  }
+}
+```
+
+**Important:** Payments are copied to the order but **not processed yet**. The payment status remains `New`.
+
+#### Step 3: Initialize Payment (Frontend → x-order → PaymentMethod)
+
+The frontend calls `initializePayment` with the `orderId` and `paymentId`:
+
+```graphql
+mutation InitializePayment($command: InputInitializePaymentType!) {
+  initializePayment(command: $command) {
+    isSuccess
+    errorMessage
+    paymentActionType        # "Standard" | "Redirection" | "PreparedForm" | "Unknown"
+    actionRedirectUrl        # URL to redirect to (for Redirection type)
+    actionHtmlForm           # HTML form to auto-submit (for PreparedForm type)
+    publicParameters { key value }  # Client-side data (tokens, scripts, etc.)
+    paymentMethodCode
+  }
+}
+```
+
+**x-order internals:** The `InitializePaymentCommandHandler` validates the payment (status must not be `Paid`, payment method must be active), then calls **`PaymentMethod.ProcessPaymentAsync(request)`**. The result determines what the frontend does next:
+
+- `ProcessPaymentRequestResult.RedirectUrl` → frontend redirects to external gateway
+- `ProcessPaymentRequestResult.HtmlForm` → frontend injects and auto-submits form
+- `ProcessPaymentRequestResult.PublicParameters` → frontend uses tokens/scripts for client-side SDK
+- None of the above → payment is done (manual/standard flow)
+
+**This step does NOT save the order.** It is a read-only initialization.
+
+#### Step 4: Payment Flow Branching (Frontend)
+
+Based on `paymentActionType` returned from Step 3:
+
+```
+┌─────────────────┐  ┌───────────────┐  ┌──────────┐  ┌──────────┐
+│   Redirection   │  │ PreparedForm  │  │ Standard │  │  Manual  │
+└────────┬────────┘  └──────┬────────┘  └────┬─────┘  └────┬─────┘
+         │                  │                │              │
+  window.location     Inject HTML       Go directly    Go directly
+  .href = redirectUrl form + auto-submit to confirmation to confirmation
+         │                  │                │              │
+         ▼                  ▼                │              │
+  ┌────────────────────────────┐             │              │
+  │   External Payment Gateway │             │              │
+  │   (PayPal, bank, 3DS...)   │             │              │
+  │   User completes payment   │             │              │
+  └────────────┬───────────────┘             │              │
+               │ redirect back               │              │
+               ▼                             │              │
+  ┌─────────────────────────┐                │              │
+  │  /payment-result page   │                │              │
+  │  Calls authorizePayment │                │              │
+  └────────────┬────────────┘                │              │
+               │                             │              │
+               ▼                             ▼              ▼
+         ┌───────────────────────────────────────────────────┐
+         │              Order Confirmation Page               │
+         └───────────────────────────────────────────────────┘
+```
+
+#### Step 5: Authorize Payment — Post-Processing (Frontend → x-order → PaymentMethod)
+
+After the user returns from an external gateway, the frontend's callback page collects all URL query parameters and calls:
+
+```graphql
+mutation AuthorizePayment($command: InputAuthorizePaymentType!) {
+  authorizePayment(command: $command) {
+    isSuccess
+    errorMessage
+  }
+}
+```
+
+**x-order internals:** The `AuthorizePaymentCommandHandler`:
+1. Calls **`PaymentMethod.ValidatePostProcessRequestAsync(parameters)`** — verifies the callback parameters (signatures, tokens, etc.)
+2. If valid, calls **`PaymentMethod.PostProcessPaymentAsync(request)`** — finalizes the payment with the gateway
+3. If successful, updates `payment.Status` to the new status (e.g., `Authorized`, `Paid`) and **saves the order**
+
+#### Step 6: Capture / Void / Refund (Back-Office Only)
+
+These operations are **not exposed via XAPI GraphQL**. They are triggered from the back-office admin UI or through platform REST APIs:
+
+| Operation | Method Called | When Used |
+|-----------|-------------|-----------|
+| **Capture** | `PaymentMethod.CaptureProcessPaymentAsync()` | Dual-message mode: capture authorized funds (full or partial) |
+| **Void** | `PaymentMethod.VoidProcessPaymentAsync()` | Cancel an authorization before capture |
+| **Refund** | `PaymentMethod.RefundProcessPaymentAsync()` | Return funds after capture |
+
+Implement `ISupportCaptureFlow` and/or `ISupportRefundFlow` marker interfaces to indicate your payment method supports these operations.
+
+### PaymentMethod Lifecycle Methods
+
+Every payment method extends the abstract `PaymentMethod` class and overrides these async methods:
+
+| Method | Purpose | Called By | When |
+|--------|---------|-----------|------|
+| `ProcessPaymentAsync` | Initialize payment with gateway. Return redirect URL, HTML form, public parameters, or just success. | `initializePayment` mutation | After order is created, before user pays |
+| `ValidatePostProcessRequestAsync` | Validate callback parameters from the gateway (signatures, tokens). | `authorizePayment` mutation | When user returns from external gateway |
+| `PostProcessPaymentAsync` | Finalize payment: confirm authorization, verify payment, update status. | `authorizePayment` mutation | After callback validation succeeds |
+| `CaptureProcessPaymentAsync` | Capture authorized funds (full or partial). | Back-office | After authorization, when ready to settle |
+| `VoidProcessPaymentAsync` | Cancel an uncaptured authorization. | Back-office | To release authorized funds |
+| `RefundProcessPaymentAsync` | Refund captured funds. | Back-office | After capture, to return money |
+
+### PaymentMethodType and PaymentMethodGroupType
+
+Your payment method must declare two enums that tell the platform and frontend how to handle the flow:
+
+**`PaymentMethodType`** — Determines the technical integration pattern:
+
+| Value | Description | ProcessPaymentAsync Returns |
+|-------|-------------|-----------------------------|
+| `Standard` | Card data entered on site (tokenized). No redirect needed. | `PublicParameters` (tokens, scripts for client-side SDK) |
+| `Redirection` | User redirected to external site to pay. | `RedirectUrl` |
+| `PreparedForm` | Gateway provides an HTML form to auto-submit. | `HtmlForm` |
+| `Unknown` | No external interaction needed (manual/offline). | Just `IsSuccess = true` |
+
+**`PaymentMethodGroupType`** — Categorizes the payment method for UI display:
+
+| Value | Examples |
+|-------|---------|
+| `BankCard` | Visa/MC via CyberSource, Stripe, Authorize.Net |
+| `Paypal` | PayPal checkout |
+| `Alternative` | Klarna, Apple Pay, Google Pay |
+| `Manual` | Wire transfer, COD, check |
+
+### Developing a Custom Payment Method
+
+#### Project Structure
+
+Create a new module with the standard three-layer structure:
+
+```
+vc-module-my-gateway/
+├── src/
+│   ├── VirtoCommerce.MyGateway.Core/
+│   │   ├── ModuleConstants.cs          # Settings definitions
+│   │   ├── Models/                     # Gateway-specific DTOs
+│   │   └── Services/
+│   │       └── IMyGatewayClient.cs     # Gateway API client interface
+│   ├── VirtoCommerce.MyGateway.Data/
+│   │   ├── Providers/
+│   │   │   └── MyGatewayPaymentMethod.cs  # THE PAYMENT METHOD
+│   │   └── Services/
+│   │       └── MyGatewayClient.cs      # Gateway API client implementation
+│   └── VirtoCommerce.MyGateway.Web/
+│       ├── Module.cs                   # DI + registration
+│       ├── module.manifest             # Dependencies: VirtoCommerce.Payment
+│       └── Localizations/
+│           └── en.MyGateway.json       # UI labels
+└── tests/
+```
+
+#### Step 1: Define Settings
+
+```csharp
+// ModuleConstants.cs
+public static class ModuleConstants
+{
+    public static class Settings
+    {
+        public static class General
+        {
+            public static SettingDescriptor Sandbox { get; } = new()
+            {
+                Name = "VirtoCommerce.Payment.MyGateway.Sandbox",
+                GroupName = "Payment|MyGateway",
+                ValueType = SettingValueType.Boolean,
+                DefaultValue = true,
+            };
+
+            public static SettingDescriptor ApiKey { get; } = new()
+            {
+                Name = "VirtoCommerce.Payment.MyGateway.ApiKey",
+                GroupName = "Payment|MyGateway",
+                ValueType = SettingValueType.SecureString,
+            };
+
+            public static IEnumerable<SettingDescriptor> AllSettings
+            {
+                get
+                {
+                    yield return Sandbox;
+                    yield return ApiKey;
+                }
+            }
+        }
+    }
+}
+```
+
+#### Step 2: Implement the Payment Method
+
+```csharp
+// MyGatewayPaymentMethod.cs
+public class MyGatewayPaymentMethod(IMyGatewayClient gatewayClient)
+    : PaymentMethod(nameof(MyGatewayPaymentMethod)), ISupportCaptureFlow, ISupportRefundFlow
+{
+    // Read settings from admin UI configuration
+    private bool Sandbox => Settings.GetValue<bool>(ModuleConstants.Settings.General.Sandbox);
+
+    // Tell the platform what kind of payment this is
+    public override PaymentMethodGroupType PaymentMethodGroupType => PaymentMethodGroupType.BankCard;
+    public override PaymentMethodType PaymentMethodType => PaymentMethodType.Redirection;
+
+    // --- PROCESS: Initialize payment, return redirect URL or tokens ---
+    public override async Task<ProcessPaymentRequestResult> ProcessPaymentAsync(
+        ProcessPaymentRequest request, CancellationToken cancellationToken = default)
+    {
+        var session = await gatewayClient.CreateSessionAsync(new CreateSessionRequest
+        {
+            Amount = ((PaymentIn)request.Payment).Sum,
+            Currency = ((CustomerOrder)request.Order).Currency,
+            ReturnUrl = $"{((Store)request.Store).SecureUrl}/payment-result" +
+                        $"?orderId={request.OrderId}&paymentId={request.PaymentId}",
+        });
+
+        return new ProcessPaymentRequestResult
+        {
+            IsSuccess = true,
+            NewPaymentStatus = PaymentStatus.Pending,
+            RedirectUrl = session.CheckoutUrl,    // <-- frontend will redirect here
+            OuterId = session.TransactionId,      // <-- store gateway's ID for later use
+        };
+    }
+
+    // --- VALIDATE: Check callback parameters from gateway ---
+    public override Task<ValidatePostProcessRequestResult> ValidatePostProcessRequestAsync(
+        NameValueCollection queryString, CancellationToken cancellationToken = default)
+    {
+        var signature = queryString["signature"];
+        var isValid = gatewayClient.VerifySignature(queryString, signature);
+
+        return Task.FromResult(new ValidatePostProcessRequestResult
+        {
+            IsSuccess = isValid,
+            ErrorMessage = isValid ? null : "Invalid signature",
+        });
+    }
+
+    // --- POST-PROCESS: Confirm payment after user returns from gateway ---
+    public override async Task<PostProcessPaymentRequestResult> PostProcessPaymentAsync(
+        PostProcessPaymentRequest request, CancellationToken cancellationToken = default)
+    {
+        var transactionId = request.Parameters["transactionId"];
+        var status = await gatewayClient.GetTransactionStatusAsync(transactionId);
+
+        var payment = (PaymentIn)request.Payment;
+        var result = new PostProcessPaymentRequestResult();
+
+        if (status == "COMPLETED")
+        {
+            result.IsSuccess = true;
+            result.NewPaymentStatus = PaymentStatus.Paid;
+            payment.IsApproved = true;
+            payment.CapturedDate = DateTime.UtcNow;
+            payment.OuterId = transactionId;
+        }
+        else
+        {
+            result.IsSuccess = false;
+            result.ErrorMessage = $"Payment status: {status}";
+            result.NewPaymentStatus = PaymentStatus.Error;
+        }
+
+        return result;
+    }
+
+    // --- CAPTURE: Settle authorized funds ---
+    public override async Task<CapturePaymentRequestResult> CaptureProcessPaymentAsync(
+        CapturePaymentRequest request, CancellationToken cancellationToken = default)
+    {
+        var payment = (PaymentIn)request.Payment;
+        await gatewayClient.CaptureAsync(payment.OuterId, request.CaptureAmount);
+
+        return new CapturePaymentRequestResult
+        {
+            IsSuccess = true,
+            NewPaymentStatus = PaymentStatus.Paid,
+        };
+    }
+
+    // --- VOID: Cancel authorization ---
+    public override async Task<VoidPaymentRequestResult> VoidProcessPaymentAsync(
+        VoidPaymentRequest request, CancellationToken cancellationToken = default)
+    {
+        var payment = (PaymentIn)request.Payment;
+        await gatewayClient.VoidAsync(payment.OuterId);
+
+        return new VoidPaymentRequestResult
+        {
+            IsSuccess = true,
+            NewPaymentStatus = PaymentStatus.Voided,
+        };
+    }
+
+    // --- REFUND: Return captured funds ---
+    public override async Task<RefundPaymentRequestResult> RefundProcessPaymentAsync(
+        RefundPaymentRequest request, CancellationToken cancellationToken = default)
+    {
+        var payment = (PaymentIn)request.Payment;
+        await gatewayClient.RefundAsync(payment.OuterId, request.AmountToRefund);
+
+        return new RefundPaymentRequestResult
+        {
+            IsSuccess = true,
+            NewRefundStatus = RefundStatus.Processed,
+        };
+    }
+}
+```
+
+#### Step 3: Register in Module.cs
+
+```csharp
+// Module.cs
+public class Module : IModule, IHasConfiguration
+{
+    public ManifestModuleInfo ModuleInfo { get; set; }
+    public IConfiguration Configuration { get; set; }
+
+    public void Initialize(IServiceCollection serviceCollection)
+    {
+        // Bind gateway credentials from appsettings.json
+        serviceCollection.AddOptions<MyGatewayOptions>()
+            .Bind(Configuration.GetSection("Payments:MyGateway"))
+            .ValidateDataAnnotations();
+
+        // Register services
+        serviceCollection.AddTransient<IMyGatewayClient, MyGatewayClient>();
+        serviceCollection.AddTransient<MyGatewayPaymentMethod>();
+    }
+
+    public void PostInitialize(IApplicationBuilder appBuilder)
+    {
+        // Register settings in admin UI
+        var settingsRegistrar = appBuilder.ApplicationServices.GetRequiredService<ISettingsRegistrar>();
+        settingsRegistrar.RegisterSettings(ModuleConstants.Settings.General.AllSettings, ModuleInfo.Id);
+
+        // Register the payment method with factory
+        var paymentMethodsRegistrar = appBuilder.ApplicationServices.GetRequiredService<IPaymentMethodsRegistrar>();
+        paymentMethodsRegistrar.RegisterPaymentMethod(
+            () => appBuilder.ApplicationServices.GetService<MyGatewayPaymentMethod>());
+
+        // Bind settings to payment method type name (appears in admin UI per-method)
+        settingsRegistrar.RegisterSettingsForType(
+            ModuleConstants.Settings.General.AllSettings,
+            nameof(MyGatewayPaymentMethod));
+    }
+
+    public void Uninstall() { }
+}
+```
+
+#### Step 4: Module Manifest
+
+```xml
+<!-- module.manifest -->
+<module>
+  <id>VirtoCommerce.MyGateway</id>
+  <version>1.0.0</version>
+  <platformVersion>3.800.0</platformVersion>
+  <dependencies>
+    <dependency id="VirtoCommerce.Payment" version="3.800.0" />
+  </dependencies>
+  <title>My Gateway Payment Module</title>
+  <description>Integrates My Gateway payment processing</description>
+  <assemblyFile>VirtoCommerce.MyGateway.Web.dll</assemblyFile>
+  <moduleType>VirtoCommerce.MyGateway.Web.Module, VirtoCommerce.MyGateway.Web</moduleType>
+</module>
+```
+
+### Key Implementation Notes
+
+1. **No frontend code needed.** The storefront handles all four `PaymentMethodType` patterns generically. Your payment method just returns the right data from `ProcessPaymentAsync` and the frontend knows what to do.
+
+2. **`PublicParameters` are your client-side bridge.** For `Standard` type methods (like tokenized card entry), return JavaScript library URLs, session tokens, and keys via `PublicParameters` — the frontend renders them.
+
+3. **`OuterId` is critical.** Store the gateway's transaction ID in `payment.OuterId` during `PostProcessPaymentAsync`. This ID is used by `CaptureProcessPaymentAsync`, `VoidProcessPaymentAsync`, and `RefundProcessPaymentAsync` to reference the original transaction.
+
+4. **Cloned objects in request.** The XAPI layer may clone `request.Order` and `request.Payment` before passing them to your method. Write results to the result object, not directly to the request objects. The XAPI handler reads `result.NewPaymentStatus`, `result.OuterId`, etc. and applies them to the real entities.
+
+5. **`initializePayment` does NOT save.** It's read-only. Only `authorizePayment` persists status changes. Design accordingly.
+
+6. **Single-message vs. Dual-message.** If your gateway supports both:
+   - **Single-message** (auth + capture in one call): Set `NewPaymentStatus = PaymentStatus.Paid` in `PostProcessPaymentAsync`.
+   - **Dual-message** (auth first, capture later): Set `NewPaymentStatus = PaymentStatus.Authorized` in `PostProcessPaymentAsync`. Implement `ISupportCaptureFlow` for the separate capture step.
+
+7. **Gateway credentials** should go in `appsettings.json` (via `IOptions<T>`), not in module settings. Use module settings for user-facing toggles (sandbox mode, payment mode, accepted card types).
+
+8. **Validation status rules:**
+   - `ProcessPaymentAsync` is called when payment status is `New` or `Custom`.
+   - `PostProcessPaymentAsync` is called when payment status is NOT `Paid`.
+   - Always set `NewPaymentStatus` in your result — the XAPI uses it to update the persisted status.
+
+### Reference: CyberSource Implementation
+
+The [vc-module-cyber-source](https://github.com/VirtoCommerce/vc-module-cyber-source) module is the reference implementation demonstrating:
+
+- `PaymentMethodType.Standard` + `PaymentMethodGroupType.BankCard` — tokenized card entry via Flex Microform
+- `ProcessPaymentAsync` returns `PublicParameters` with JWT capture context and client library URL
+- `PostProcessPaymentAsync` receives the transient token and calls CyberSource's Payments API
+- Single-message (auth+capture) and Dual-message (auth only) modes via settings
+- Full Capture, Void, and Refund implementations
+- Separated `ICyberSourceClient` for testability
+- `appsettings.json` configuration for merchant credentials
 
 ## Documentation
 
 * [Payment module user documentation](https://docs.virtocommerce.org/platform/user-guide/payment/overview/)
 * [REST API](https://virtostart-demo-admin.govirto.com/docs/index.html?urls.primaryName=VirtoCommerce.Payment)
-* [View on Github](https://github.com/VirtoCommerce/vc-module-payment)
+* [View on GitHub](https://github.com/VirtoCommerce/vc-module-payment)
 
 ## References
 
@@ -28,6 +565,7 @@ The Payment Module provides the ability to extend payment provider list with cus
 * [Download latest release](https://github.com/VirtoCommerce/vc-module-payment/releases/latest)
 
 ## License
+
 Copyright (c) Virto Solutions LTD. All rights reserved.
 
 Licensed under the Virto Commerce Open Software License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/src/VirtoCommerce.Payment.Core/VirtoCommerce.PaymentModule.Core.csproj
+++ b/src/VirtoCommerce.Payment.Core/VirtoCommerce.PaymentModule.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
     <noWarn>1591</noWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.824.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Payment.Data/VirtoCommerce.PaymentModule.Data.csproj
+++ b/src/VirtoCommerce.Payment.Data/VirtoCommerce.PaymentModule.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
     <noWarn>1591</noWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -9,8 +9,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Core\VirtoCommerce.PaymentModule.Core.csproj" />

--- a/src/VirtoCommerce.Payment.Web/VirtoCommerce.PaymentModule.Web.csproj
+++ b/src/VirtoCommerce.Payment.Web/VirtoCommerce.PaymentModule.Web.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>False</IsPackable>
-    <noWarn>1591</noWarn>
+    <noWarn>1591;NU1608</noWarn>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
     <None Remove="VirtoCommerce.Platform.Core" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[8.0.11,9)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Core\VirtoCommerce.PaymentModule.Core.csproj" />

--- a/src/VirtoCommerce.Payment.Web/module.manifest
+++ b/src/VirtoCommerce.Payment.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Payment</id>
-  <version>3.814.0</version>
+  <version>3.1000.0</version>
   <version-tag />
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.824.0" />
-    <dependency id="VirtoCommerce.Store" version="3.823.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
   </dependencies>
   <title>Payment module</title>
   <description>Provides management and integration of various payment methods.</description>  
@@ -20,7 +20,7 @@
   <iconUrl>Modules/$(VirtoCommerce.Payment)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2026 Virto Commerce. All rights reserved</copyright>
   <tags>payments</tags>
   <assemblyFile>VirtoCommerce.PaymentModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.PaymentModule.Web.Module, VirtoCommerce.PaymentModule.Web</moduleType>

--- a/src/VirtoCommerce.Payment.Web/package-lock.json
+++ b/src/VirtoCommerce.Payment.Web/package-lock.json
@@ -84,11 +84,34 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -101,10 +124,11 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -119,148 +143,163 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
-      "dev": true
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -304,19 +343,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -324,13 +366,17 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
       "peerDependencies": {
-        "acorn": "^8"
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/ajv": {
@@ -405,6 +451,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -416,19 +472,20 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -444,11 +501,13 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -482,9 +541,9 @@
       "license": "0BSD"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001664",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
-      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
+      "version": "1.0.30001769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
+      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
       "dev": true,
       "funding": [
         {
@@ -499,7 +558,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
@@ -663,10 +723,11 @@
       "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.29",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
-      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
-      "dev": true
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
@@ -679,13 +740,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -717,16 +779,18 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -789,12 +853,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -853,7 +911,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/globby": {
       "version": "6.1.0",
@@ -884,7 +943,8 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -903,6 +963,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1093,6 +1154,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -1146,12 +1208,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -1202,7 +1269,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -1320,10 +1388,11 @@
       "license": "0BSD"
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -1659,6 +1728,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -1762,21 +1832,23 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
+        "ajv": "^8.9.0",
         "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
+        "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1801,6 +1873,7 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -1872,6 +1945,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1895,12 +1969,17 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
@@ -1922,16 +2001,17 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.20",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.26.0"
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -1955,55 +2035,6 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -2011,9 +2042,9 @@
       "dev": true
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -2029,9 +2060,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -2056,10 +2088,11 @@
       "dev": true
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -2069,34 +2102,37 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.95.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
-      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "version": "5.105.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -2184,61 +2220,13 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/which": {

--- a/src/VirtoCommerce.PaymentModule.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.PaymentModule.Data.MySql/Readme.md
@@ -1,24 +1,19 @@
+# Generate Migrations
 
-## Package manager 
-Add-Migration Initial -Context VirtoCommerce.PaymentModule.Data.Repositories.PaymentDbContext  -Verbose -OutputDir Migrations -Project VirtoCommerce.PaymentModule.Data.MySql -StartupProject VirtoCommerce.PaymentModule.Data.MySql  -Debug
-
-
-
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 6.*
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
+or update
 
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-
-`dotnet ef database update -- "{connection string}"`
+```cmd
+dotnet ef migrations add <migration-name>
+```

--- a/src/VirtoCommerce.PaymentModule.Data.MySql/VirtoCommerce.PaymentModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.MySql/VirtoCommerce.PaymentModule.Data.MySql.csproj
@@ -1,19 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />

--- a/src/VirtoCommerce.PaymentModule.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.PaymentModule.Data.PostgreSql/Readme.md
@@ -1,24 +1,19 @@
+# Generate Migrations
 
-## Package manager 
-Add-Migration Initial -Context VirtoCommerce.PaymentModule.Data.Repositories.PaymentDbContext  -Verbose -OutputDir Migrations -Project VirtoCommerce.PaymentModule.Data.PostgreSql -StartupProject VirtoCommerce.PaymentModule.Data.PostgreSql  -Debug
-
-
-
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 6.*
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
+or update
 
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-
-`dotnet ef database update -- "{connection string}"`
+```cmd
+dotnet ef migrations add <migration-name>
+```

--- a/src/VirtoCommerce.PaymentModule.Data.PostgreSql/VirtoCommerce.PaymentModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.PostgreSql/VirtoCommerce.PaymentModule.Data.PostgreSql.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />

--- a/src/VirtoCommerce.PaymentModule.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.PaymentModule.Data.SqlServer/Readme.md
@@ -1,25 +1,19 @@
+# Generate Migrations
 
-## Package manager 
-Add-Migration Initial -Context VirtoCommerce.PaymentModule.Data.Repositories.PaymentDbContext  -Verbose -OutputDir Migrations -Project VirtoCommerce.PaymentModule.Data.SqlServer -StartupProject VirtoCommerce.PaymentModule.Data.SqlServer  -Debug
-
-
-
-### Entity Framework Core Commands
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-dotnet tool install --global dotnet-ef --version 6.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
+```cmd
+dotnet ef migrations add <migration-name>
 ```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-
-etc..
-
-**Apply Migrations**
-
-`dotnet ef database update -- "{connection string}"`

--- a/src/VirtoCommerce.PaymentModule.Data.SqlServer/VirtoCommerce.PaymentModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.SqlServer/VirtoCommerce.PaymentModule.Data.SqlServer.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />

--- a/tests/VirtoCommerce.Payment.Tests/PaymentMethodAsyncTests.cs
+++ b/tests/VirtoCommerce.Payment.Tests/PaymentMethodAsyncTests.cs
@@ -126,7 +126,7 @@ namespace VirtoCommerce.Payment.Tests
             var request = new ProcessPaymentRequest();
 
             // Act
-            var result = await method.ProcessPaymentAsync(request);
+            var result = await method.ProcessPaymentAsync(request, TestContext.Current.CancellationToken);
 
             // Assert
             method.SyncMethodCalled.Should().BeTrue();
@@ -168,7 +168,7 @@ namespace VirtoCommerce.Payment.Tests
             var request = new ProcessPaymentRequest();
 
             // Act
-            var result = await method.ProcessPaymentAsync(request);
+            var result = await method.ProcessPaymentAsync(request, TestContext.Current.CancellationToken);
 
             // Assert
             method.AsyncMethodCalled.Should().BeTrue();

--- a/tests/VirtoCommerce.Payment.Tests/VirtoCommerce.Payment.Tests.csproj
+++ b/tests/VirtoCommerce.Payment.Tests/VirtoCommerce.Payment.Tests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <noWarn>1591</noWarn>
+    <TargetFramework>net10.0</TargetFramework>
+    <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MockQueryable.Moq" Version="7.0.3" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MockQueryable.Moq" Version="10.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.7" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Moq.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.Payment.Core\VirtoCommerce.PaymentModule.Core.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Payment_3.1000.0-pr-71-c0a6.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades target framework and core platform/EF dependencies across the module, which can introduce runtime/build compatibility issues. Functional code changes are minimal, but dependency/tooling shifts are broad.
> 
> **Overview**
> Upgrades the module from `net8.0` to `net10.0`, bumps `VersionPrefix`/`module.manifest` to `3.1000.0`, and updates platform/core/store dependency versions (and copyright year).
> 
> Updates web/data provider projects to .NET 10-era packages (e.g., `Microsoft.AspNetCore.Mvc.NewtonsoftJson` `10.0.1`, `Microsoft.EntityFrameworkCore.Design` `10.0.1`), adds `NU1608` to `NoWarn` where needed, and refreshes the web `package-lock.json` dependency graph.
> 
> Modernizes docs (expanded `README.md` and provider migration READMEs) and adjusts tests for the updated async API usage by passing `TestContext.Current.CancellationToken`, while also updating test dependencies (including moving to `xunit.v3`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a665024c8f111cb015d6efc331023b7b6fdfd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->