### PR TITLE
VCST-5163: Stable 15 — Payment (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.Payment.Core/VirtoCommerce.PaymentModule.Core.csproj
+++ b/src/VirtoCommerce.Payment.Core/VirtoCommerce.PaymentModule.Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Payment.Data/ExportImport/PaymentExportImport.cs
+++ b/src/VirtoCommerce.Payment.Data/ExportImport/PaymentExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -27,7 +28,7 @@ namespace VirtoCommerce.PaymentModule.Data.ExportImport
             _jsonSerializer = jsonSerializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -62,7 +63,7 @@ namespace VirtoCommerce.PaymentModule.Data.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.Payment.Data/ExportImport/PaymentExportImport.cs
+++ b/src/VirtoCommerce.Payment.Data/ExportImport/PaymentExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
@@ -38,12 +39,12 @@ namespace VirtoCommerce.PaymentModule.Data.ExportImport
             using (var sw = new StreamWriter(outStream))
             using (var writer = new JsonTextWriter(sw))
             {
-                await writer.WriteStartObjectAsync();
+                await writer.WriteStartObjectAsync(cancellationToken);
 
                 progressInfo.Description = "Payment methods are started to export";
                 progressCallback(progressInfo);
 
-                await writer.WritePropertyNameAsync("PaymentMethods");
+                await writer.WritePropertyNameAsync("PaymentMethods", cancellationToken);
                 await writer.SerializeArrayWithPagingAsync(_jsonSerializer, _batchSize, async (skip, take) =>
                 {
                     var searchCriteria = AbstractTypeFactory<PaymentMethodsSearchCriteria>.TryCreateInstance();
@@ -58,8 +59,8 @@ namespace VirtoCommerce.PaymentModule.Data.ExportImport
                     progressCallback(progressInfo);
                 }, cancellationToken);
 
-                await writer.WriteEndObjectAsync();
-                await writer.FlushAsync();
+                await writer.WriteEndObjectAsync(cancellationToken);
+                await writer.FlushAsync(cancellationToken);
             }
         }
 
@@ -72,7 +73,7 @@ namespace VirtoCommerce.PaymentModule.Data.ExportImport
             using (var streamReader = new StreamReader(inputStream))
             using (var reader = new JsonTextReader(streamReader))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(cancellationToken))
                 {
                     if (reader.TokenType == JsonToken.PropertyName)
                     {

--- a/src/VirtoCommerce.Payment.Data/VirtoCommerce.PaymentModule.Data.csproj
+++ b/src/VirtoCommerce.Payment.Data/VirtoCommerce.PaymentModule.Data.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Core\VirtoCommerce.PaymentModule.Core.csproj" />

--- a/src/VirtoCommerce.Payment.Web/Module.cs
+++ b/src/VirtoCommerce.Payment.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -101,14 +102,14 @@ namespace VirtoCommerce.PaymentModule.Web
         }
 
         public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<PaymentExportImport>().DoExportAsync(outStream,
                 progressCallback, cancellationToken);
         }
 
         public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<PaymentExportImport>().DoImportAsync(inputStream,
                 progressCallback, cancellationToken);

--- a/src/VirtoCommerce.Payment.Web/VirtoCommerce.PaymentModule.Web.csproj
+++ b/src/VirtoCommerce.Payment.Web/VirtoCommerce.PaymentModule.Web.csproj
@@ -17,7 +17,7 @@
     <None Remove="VirtoCommerce.Platform.Core" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Core\VirtoCommerce.PaymentModule.Core.csproj" />

--- a/src/VirtoCommerce.Payment.Web/module.manifest
+++ b/src/VirtoCommerce.Payment.Web/module.manifest
@@ -3,10 +3,10 @@
   <id>VirtoCommerce.Payment</id>
   <version>3.1004.0</version>
   <version-tag />
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
   <title>Payment module</title>
   <description>Provides management and integration of various payment methods.</description>  

--- a/src/VirtoCommerce.PaymentModule.Data.MySql/VirtoCommerce.PaymentModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.MySql/VirtoCommerce.PaymentModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />

--- a/src/VirtoCommerce.PaymentModule.Data.PostgreSql/VirtoCommerce.PaymentModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.PostgreSql/VirtoCommerce.PaymentModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />

--- a/src/VirtoCommerce.PaymentModule.Data.SqlServer/VirtoCommerce.PaymentModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.PaymentModule.Data.SqlServer/VirtoCommerce.PaymentModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Payment.Data\VirtoCommerce.PaymentModule.Data.csproj" />


### PR DESCRIPTION
Part of **Stable 15** (Wave 4). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–3 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration; NU1605 NewtonsoftJson bump.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment export/import cancellation behavior and requires coordinated platform/module versions at deploy time; logic is mostly signature and dependency alignment rather than new payment flows.
> 
> **Overview**
> Aligns the Payment module with **Virto Commerce platform 3.1039.0** (Stable 15): `module.manifest` `platformVersion` and NuGet references for Platform.Core/Data and DB provider packages move from 3.1007.x to **3.1039.0**; **Core** and **Store** dependency versions in the manifest are bumped to match Wave packages.
> 
> Export/import code and `Module` **ExportAsync** / **ImportAsync** now use **`CancellationToken`** instead of **`ICancellationToken`**, and JSON writer/reader async calls pass the token through (e.g. `WriteStartObjectAsync`, `ReadAsync`).
> 
> **Microsoft.AspNetCore.Mvc.NewtonsoftJson** is raised **10.0.7 → 10.0.9** to resolve NU1605 with the updated platform stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189cac690efe74281278f0c8ad40d52e6bb73314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Payment_3.1004.0-pr-73-189c.zip